### PR TITLE
Potential fix for code scanning alert no. 2: Inefficient regular expression

### DIFF
--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -105,7 +105,7 @@ describe("CLI integration tests", () => {
 
     expect(result.code).toBe(0);
     // Accept versions like '1.2.3', '1.2.3-alpha.1', or '1.2.3+build.123'
-    expect(result.stdout.trim()).toMatch(/^[A-Za-z0-9.+-]+(?:\.[A-Za-z0-9.+-]+)+$/);
+    expect(result.stdout.trim()).toMatch(/^[A-Za-z0-9+-]+(?:\.[A-Za-z0-9+-]+)+$/);
   });
 
   test("should merge files successfully", async () => {


### PR DESCRIPTION
Potential fix for [https://github.com/gradientedge/merge-jsonc/security/code-scanning/2](https://github.com/gradientedge/merge-jsonc/security/code-scanning/2)

To fix the problem, we should modify the regular expression in the `toMatch` assertion on line 108 so it does not allow for ambiguous overlapping matches that would cause backtracking. We can achieve this by being more specific about what characters or groups are allowed between the dots in the version string.

- The original: `/^[A-Za-z0-9.+-]+(?:\.[A-Za-z0-9.+-]+)+$/`
- The problematic bit: `[A-Za-z0-9.+-]+` inside and outside the non-capturing group, allows ambiguous concatenation of `"."`, `"+"`, and `"-"`.

One way to fix: break the ambiguity of single-character repetition by not allowing `"."` within the character class when matching dot-separated groups.

A simple, efficient and correct alternative for version strings is:
- The leading group: `[A-Za-z0-9+-]+`
- Dot separator: `\.` (literal dot)
- Then one or more more `[A-Za-z0-9+-]+` parts, without including `.` in the class.

So, use: `/^[A-Za-z0-9+-]+(?:\.[A-Za-z0-9+-]+)+$/`

**Change:**  
- Replace `/^[A-Za-z0-9.+-]+(?:\.[A-Za-z0-9.+-]+)+$/`  
- With `/^[A-Za-z0-9+-]+(?:\.[A-Za-z0-9+-]+)+$/`

No new imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
