### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5


### PR DESCRIPTION
Potential fix for [https://github.com/gradientedge/merge-jsonc/security/code-scanning/1](https://github.com/gradientedge/merge-jsonc/security/code-scanning/1)

The best way to fix the issue is to add a `permissions` block to the `ci` job, which begins on line 9 of `.github/workflows/release.yml`. The permissions should be restricted to the minimal set required. For a typical CI job that performs checkout, install, lint, build, and test, but does not push, publish, open issues, or otherwise interact with repo resources via the GitHub API, only `contents: read` is likely required. You should insert the `permissions:` block directly under the job definition (below `runs-on:` and above `steps:`), aligned with YAML indentation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
